### PR TITLE
Implement publish command

### DIFF
--- a/api.go
+++ b/api.go
@@ -142,7 +142,11 @@ func githubGet(uri string, v interface{}, isURL bool) error {
 	}
 	vv.Set(reflect.AppendSlice(vv, sub.Elem()))
 
-	links := parseHdrLink(resp.Header.Get("Link"))
+	linkHeader := resp.Header.Get("Link")
+	if linkHeader == "" {
+		return nil
+	}
+	links := parseHdrLink(linkHeader)
 	if nextURL, ok := links["next"]; ok {
 		return githubGet(nextURL, v, true)
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -422,3 +422,68 @@ func httpDelete(url, token string) (*http.Response, error) {
 
 	return resp, nil
 }
+
+func publishcmd(opt Options) error {
+	cmdopt := opt.Publish
+	user := nvls(cmdopt.User, EnvUser)
+	repo := nvls(cmdopt.Repo, EnvRepo)
+	token := nvls(cmdopt.Token, EnvToken)
+	tag := cmdopt.Tag
+
+	vprintln("publishing...")
+
+	if err := ValidateCredentials(user, repo, token, tag); err != nil {
+		return err
+	}
+
+	/* look up the release */
+	vprintf("%v/%v/%v: getting information for the release\n", user, repo, tag)
+	release, err := ReleaseOfTag(user, repo, tag, token)
+	if err != nil {
+		return err
+	}
+
+	vprintf("release %v has id %v\n", tag, release.Id)
+
+	/* the release create struct works for editing releases as well */
+	params := ReleaseCreate{
+		TagName:    release.TagName,
+		Name:       release.Name,
+		Body:       release.Description,
+		Draft:      false,
+		Prerelease: release.Prerelease,
+	}
+
+	/* encode the parameters as JSON, as required by the github API */
+	payload, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("can't encode release edit params, %v", err)
+	}
+
+	uri := fmt.Sprintf("/repos/%s/%s/releases/%d", user, repo, release.Id)
+	resp, err := DoAuthRequest("PATCH", ApiURL()+uri, "application/json",
+		token, nil, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("while submitting %v, %v", string(payload), err)
+	}
+	defer resp.Body.Close()
+
+	vprintln("RESPONSE:", resp)
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == 422 {
+			return fmt.Errorf("github returned %v (this is probably because the release already exists)",
+				resp.Status)
+		}
+		return fmt.Errorf("github returned unexpected status code %v", resp.Status)
+	}
+
+	if VERBOSITY != 0 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("error while reading response, %v", err)
+		}
+		vprintln("BODY:", string(body))
+	}
+
+	return nil
+}

--- a/github-release.go
+++ b/github-release.go
@@ -64,6 +64,12 @@ type Options struct {
 		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Tag   string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
 	} `goptions:"info"`
+	Publish struct {
+		Token string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
+		User  string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Tag   string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
+	} `goptions:"publish"`
 }
 
 type Command func(Options) error
@@ -75,6 +81,7 @@ var commands = map[goptions.Verbs]Command{
 	"edit":     editcmd,
 	"delete":   deletecmd,
 	"info":     infocmd,
+	"publish":  publishcmd,
 }
 
 var (


### PR DESCRIPTION
It is not straightforward to use `github-release edit` to remove the 'draft' status from a release because you have to resupply all of the arguments that you don't want to change; this PR adds a `github-release publish` command which effectively implements the 'Publish release' button in the GitHub UI. We're currently using this modification as part of our release process and would like to contribute it upstream weaveworks/weave#1430.
