### PR TITLE
Use Current Working Directory Github Info

### DIFF
--- a/github-release.go
+++ b/github-release.go
@@ -89,9 +89,11 @@ var (
 )
 
 func init() {
+	user, repo := gitUserAndRepo()
+
 	EnvToken = os.Getenv("GITHUB_TOKEN")
-	EnvUser = os.Getenv("GITHUB_USER")
-	EnvRepo = os.Getenv("GITHUB_REPO")
+	EnvUser = nvls(os.Getenv("GITHUB_USER"), user)
+	EnvRepo = nvls(os.Getenv("GITHUB_REPO"), repo)
 	EnvApiEndpoint = os.Getenv("GITHUB_API")
 }
 

--- a/util.go
+++ b/util.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -38,4 +41,29 @@ func timeFmtOr(t *time.Time, fmt, def string) string {
 		return def
 	}
 	return t.Format(fmt)
+}
+
+func gitUserAndRepo() (string, string) {
+	var repo string
+	var user string
+	origin, execErr := exec.Command("git", "config", "--get", "remote.origin.url").Output()
+	if execErr == nil {
+		originStr := string(origin[:])
+		if strings.Contains(originStr, "git@") {
+			originSegments := strings.Split(originStr, ":")
+			uriSegments := strings.Split(originSegments[1], "/")
+			repoSegments := strings.Split(uriSegments[1], ".")
+			repo = repoSegments[0]
+			user = uriSegments[0]
+		} else {
+			url, parseErr := url.Parse(originStr)
+			if parseErr == nil {
+				uriSegments := strings.Split(url.Path, "/")
+				repoSegments := strings.Split(uriSegments[2], ".")
+				repo = repoSegments[0]
+				user = uriSegments[1]
+			}
+		}
+	}
+	return user, repo
 }


### PR DESCRIPTION
This change executes `git config --get remote.origin.url`, parses the output, and assigns `EnvUser` and `EnvRepo` to the parsed values if the environment variables `GITHUB_USER` and `GITHUB_REPO` aren't set, respectively.
