### PR TITLE
fix(github.go): redact url access token value in error message

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -155,7 +155,7 @@ func (c Client) getPaginated(uri string) (io.ReadCloser, error) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		return nil, fmt.Errorf("expected '200 OK' but received '%v' (url: %s)", resp.Status, resp.Request.URL)
+		return nil, fmt.Errorf("expected '200 OK' but received '%v' (url: %s)", resp.Status, redactedURL(resp.Request.URL))
 	}
 	vprintln("GET (top-level)", resp.Request.URL, "->", resp)
 
@@ -210,7 +210,7 @@ func (c Client) getPaginated(uri string) (io.ReadCloser, error) {
 		for resp := range responses {
 			if resp.StatusCode != http.StatusOK {
 				resp.Body.Close()
-				w.CloseWithError(fmt.Errorf("expected '200 OK' but received '%v' (url: %s)", resp.Status, resp.Request.URL))
+				w.CloseWithError(fmt.Errorf("expected '200 OK' but received '%v' (url: %s)", resp.Status, redactedURL(resp.Request.URL)))
 				return
 			}
 			_, err := io.Copy(w, resp.Body)
@@ -274,4 +274,18 @@ func nextLink(links linkheader.Links) string {
 		}
 	}
 	return ""
+}
+
+// redactedURL returns a given URL but with an access_token query value
+// redacted, if present
+func redactedURL(url *url.URL) *url.URL {
+	redactedURL := url
+	queries := redactedURL.Query()
+
+	if queries["access_token"] != nil {
+		queries.Set("access_token", "REDACTED")
+	}
+
+	redactedURL.RawQuery = queries.Encode()
+	return redactedURL
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1,0 +1,52 @@
+package github
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestRedactedURL(t *testing.T) {
+	type testCase struct {
+		name     string
+		initial  *url.URL
+		expected *url.URL
+	}
+
+	testCases := []testCase{
+		testCase{
+			name: "without access_token query",
+			initial: &url.URL{
+				Host:     "example.com",
+				Scheme:   "https",
+				RawQuery: "foo=bar",
+			},
+			expected: &url.URL{
+				Host:     "example.com",
+				Scheme:   "https",
+				RawQuery: "foo=bar",
+			},
+		},
+		testCase{
+			name: "with access_token query",
+			initial: &url.URL{
+				Host:     "example.com",
+				Scheme:   "https",
+				RawQuery: "access_token=secret&foo=bar",
+			},
+			expected: &url.URL{
+				Host:     "example.com",
+				Scheme:   "https",
+				RawQuery: "access_token=REDACTED&foo=bar",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL := redactedURL(tc.initial)
+			if tc.expected.String() != gotURL.String() {
+				t.Fatalf("URLs do not match; want: %s, got %s", tc.expected.String(), gotURL.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Masks the `access_token` query value, if present, in applicable error messages.  If logs are public, this is needed to avoid leaking this secret.

Note that if verbose logging is enabled, there is at least one instance where it will remain unredacted.