### PR TITLE
Implement publish command

### DIFF
--- a/github-release.go
+++ b/github-release.go
@@ -74,6 +74,12 @@ type Options struct {
 		Tag      string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
 		JSON     bool   `goptions:"-j, --json, description='Emit info as JSON instead of text'"`
 	} `goptions:"info"`
+	Publish struct {
+		Token string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
+		User  string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Tag   string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
+	} `goptions:"publish"`
 }
 
 type Command func(Options) error
@@ -85,6 +91,7 @@ var commands = map[goptions.Verbs]Command{
 	"edit":     editcmd,
 	"delete":   deletecmd,
 	"info":     infocmd,
+	"publish":  publishcmd,
 }
 
 var (


### PR DESCRIPTION
This is a rebase of #34 

Original description:
> It is not straightforward to use github-release edit to remove the 'draft' status from a release because you have to resupply all of the arguments that you don't want to change; this PR adds a github-release publish command which effectively implements the 'Publish release' button in the GitHub UI. 