### PR TITLE
Add generate-release-notes flag to release subcommand 

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -317,11 +317,16 @@ func releasecmd(opt Options) error {
 	repo := nvls(cmdopt.Repo, EnvRepo)
 	token := nvls(cmdopt.Token, EnvToken)
 	tag := cmdopt.Tag
-	name := nvls(cmdopt.Name, tag)
-	desc := nvls(cmdopt.Desc, tag)
+	name := cmdopt.Name
+	desc := cmdopt.Desc
 	target := nvls(cmdopt.Target)
 	draft := cmdopt.Draft
 	prerelease := cmdopt.Prerelease
+	generateReleaseNotes := cmdopt.GenerateReleaseNotes
+	if !generateReleaseNotes {
+		name = nvls(name, tag)
+		desc = nvls(desc, tag)
+	}
 
 	vprintln("releasing...")
 
@@ -339,12 +344,13 @@ func releasecmd(opt Options) error {
 	}
 
 	params := ReleaseCreate{
-		TagName:         tag,
-		TargetCommitish: target,
-		Name:            name,
-		Body:            desc,
-		Draft:           draft,
-		Prerelease:      prerelease,
+		TagName:              tag,
+		TargetCommitish:      target,
+		Name:                 name,
+		Body:                 desc,
+		Draft:                draft,
+		Prerelease:           prerelease,
+		GenerateReleaseNotes: generateReleaseNotes,
 	}
 
 	/* encode params as json */

--- a/github-release.go
+++ b/github-release.go
@@ -38,15 +38,16 @@ type Options struct {
 		Replace  bool     `goptions:"-R, --replace, description='Replace asset with same name if it already exists (WARNING: not atomic, failure to upload will remove the original asset too)'"`
 	} `goptions:"upload"`
 	Release struct {
-		Token      string `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
-		User       string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
-		Repo       string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
-		Tag        string `goptions:"-t, --tag, obligatory, description='Git tag to create a release from'"`
-		Name       string `goptions:"-n, --name, description='Name of the release (defaults to tag)'"`
-		Desc       string `goptions:"-d, --description, description='Release description, use - for reading a description from stdin (defaults to tag)'"`
-		Target     string `goptions:"-c, --target, description='Commit SHA or branch to create release of (defaults to the repository default branch)'"`
-		Draft      bool   `goptions:"--draft, description='The release is a draft'"`
-		Prerelease bool   `goptions:"-p, --pre-release, description='The release is a pre-release'"`
+		Token                string `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
+		User                 string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
+		Repo                 string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Tag                  string `goptions:"-t, --tag, obligatory, description='Git tag to create a release from'"`
+		Name                 string `goptions:"-n, --name, description='Name of the release (defaults to tag)'"`
+		Desc                 string `goptions:"-d, --description, description='Release description, use - for reading a description from stdin (defaults to tag)'"`
+		Target               string `goptions:"-c, --target, description='Commit SHA or branch to create release of (defaults to the repository default branch)'"`
+		Draft                bool   `goptions:"--draft, description='The release is a draft'"`
+		Prerelease           bool   `goptions:"-p, --pre-release, description='The release is a pre-release'"`
+		GenerateReleaseNotes bool   `goptions:"-g, --generate-release-notes, description='Generate name and description if not given'"`
 	} `goptions:"release"`
 	Edit struct {
 		Token      string `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`

--- a/releases.go
+++ b/releases.go
@@ -59,12 +59,13 @@ func (r *Release) String() string {
 }
 
 type ReleaseCreate struct {
-	TagName         string `json:"tag_name"`
-	TargetCommitish string `json:"target_commitish,omitempty"`
-	Name            string `json:"name"`
-	Body            string `json:"body"`
-	Draft           bool   `json:"draft"`
-	Prerelease      bool   `json:"prerelease"`
+	TagName              string `json:"tag_name"`
+	TargetCommitish      string `json:"target_commitish,omitempty"`
+	Name                 string `json:"name"`
+	Body                 string `json:"body"`
+	Draft                bool   `json:"draft"`
+	Prerelease           bool   `json:"prerelease"`
+	GenerateReleaseNotes bool   `json:"generate_release_notes"`
 }
 
 func Releases(user, repo, authUser, token string) ([]Release, error) {


### PR DESCRIPTION
The GitHub REST API for releases has the option to generate the name and description from the merged PRs since the last release. This commit also adds the option to the release subcommand.

This should not be a backwards breaking change, because the name and the description still defaults to the tag, if the -g argument is not given. If the -g argument is given, the name will be empty and GitHub will display the tag in the web interface and the description will be the automatically created description by GitHub.